### PR TITLE
Update build script to not remove 'lib/commonjs/index.js'

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "!**/__mocks__"
   ],
   "scripts": {
-    "build": "rm -rf lib && bob build && rm lib/module/index.js && rm lib/commonjs/index.js",
+    "build": "rm -rf lib && bob build && rm lib/module/index.js",
     "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",


### PR DESCRIPTION
Per [this comment](https://github.com/GetStream/flat-list-mvcp/issues/9#issuecomment-1007892555) to resolve the same issue when running jest.